### PR TITLE
Avoid accessing not existing registry key on 32-bit systems

### DIFF
--- a/scripts/Get-VcRedistUninstall.ps1
+++ b/scripts/Get-VcRedistUninstall.ps1
@@ -3,6 +3,10 @@
         Simple script for listing the DiplayName and UninstallString for the Visual C++ Redistributables.
         Used to grab GUIDs when Redistributables are updated.
 #>
-Get-ChildItem -Path HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall, HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall | `
+$UninstallPath = @('HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall')
+If ([System.Environment]::Is64BitOperatingSystem) {
+    $UninstallPath += 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
+}
+Get-ChildItem -Path $UninstallPath | `
 Get-ItemProperty | Where-Object {$_.DisplayName -like "Microsoft Visual C*"} | Select-Object Publisher, DisplayName, DisplayVersion, UninstallString | `
 Sort-Object DisplayName


### PR DESCRIPTION
When running `Install-VcRedist` on a 32 bit systems, we have this issue:

```powershell
Get-ChildItem : Cannot find path 'HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall'
because it does not exist.
At C:\Users\IEUser\Documents\WindowsPowerShell\Modules\VcRedist\1.3.2.37\Public\Install-VcRedist.ps1:82 char:17
+             If (Get-ChildItem -Path $UninstallPath | Where-Object { $ ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Let's avoid accessing non existing registry keys (Wow6432Node does not exist on 32-bit OSs).