### PR TITLE
Update 2017 VcRedists; Fix Changelog; Update module ReleaseNotes link

### DIFF
--- a/VcRedist/Manifests/VisualCRedistributablesAll.xml
+++ b/VcRedist/Manifests/VisualCRedistributablesAll.xml
@@ -240,8 +240,8 @@
             <Name>Visual C++ Redistributable for Visual Studio 2017</Name>
             <ShortName>RTM</ShortName>
             <URL>https://www.visualstudio.com/downloads/</URL>
-            <ProductCode>{e2ee15e2-a480-4bc5-bfb7-e9803d1d9823}</ProductCode>
-            <Download>https://download.visualstudio.microsoft.com/download/pr/100349091/2cd2dba5748dc95950a5c42c2d2d78e4/VC_redist.x64.exe</Download>
+            <ProductCode>{7474cd6e-76cc-4257-837e-5b9261e526af}</ProductCode>
+            <Download>https://download.visualstudio.microsoft.com/download/pr/11687625/2cd2dba5748dc95950a5c42c2d2d78e4/VC_redist.x64.exe</Download>
         </Redistributable>
     </Platform>
     <Platform Architecture="x86" Release="2017" Install="/install /passive /norestart">
@@ -249,8 +249,8 @@
             <Name>Visual C++ Redistributable for Visual Studio 2017</Name>
             <ShortName>RTM</ShortName>
             <URL>https://www.visualstudio.com/downloads/</URL>
-            <ProductCode>{56e11d69-7cc9-40a5-a4f9-8f6190c4d84d}</ProductCode>
-            <Download>https://download.visualstudio.microsoft.com/download/pr/100349138/88b50ce70017bf10f2d56d60fcba6ab1/VC_redist.x86.exe</Download>
+            <ProductCode>{5c045b7f-e561-4794-91f8-c6cda0893107}</ProductCode>
+            <Download>https://download.visualstudio.microsoft.com/download/pr/11687613/88b50ce70017bf10f2d56d60fcba6ab1/VC_redist.x86.exe</Download>
         </Redistributable>
     </Platform>
 </Redistributables>

--- a/VcRedist/Manifests/VisualCRedistributablesSupported.xml
+++ b/VcRedist/Manifests/VisualCRedistributablesSupported.xml
@@ -96,8 +96,8 @@
             <Name>Visual C++ Redistributable for Visual Studio 2017</Name>
             <ShortName>RTM</ShortName>
             <URL>https://www.visualstudio.com/downloads/</URL>
-            <ProductCode>{e2ee15e2-a480-4bc5-bfb7-e9803d1d9823}</ProductCode>
-            <Download>https://download.visualstudio.microsoft.com/download/pr/100349091/2cd2dba5748dc95950a5c42c2d2d78e4/VC_redist.x64.exe</Download>
+            <ProductCode>{7474cd6e-76cc-4257-837e-5b9261e526af}</ProductCode>
+            <Download>https://download.visualstudio.microsoft.com/download/pr/11687625/2cd2dba5748dc95950a5c42c2d2d78e4/VC_redist.x64.exe</Download>
         </Redistributable>
     </Platform>
     <Platform Architecture="x86" Release="2017" Install="/install /passive /norestart">
@@ -105,8 +105,8 @@
             <Name>Visual C++ Redistributable for Visual Studio 2017</Name>
             <ShortName>RTM</ShortName>
             <URL>https://www.visualstudio.com/downloads/</URL>
-            <ProductCode>{56e11d69-7cc9-40a5-a4f9-8f6190c4d84d}</ProductCode>
-            <Download>https://download.visualstudio.microsoft.com/download/pr/100349138/88b50ce70017bf10f2d56d60fcba6ab1/VC_redist.x86.exe</Download>
+            <ProductCode>{5c045b7f-e561-4794-91f8-c6cda0893107}</ProductCode>
+            <Download>https://download.visualstudio.microsoft.com/download/pr/11687613/88b50ce70017bf10f2d56d60fcba6ab1/VC_redist.x86.exe</Download>
         </Redistributable>
     </Platform>
 </Redistributables>

--- a/VcRedist/Public/Export-VcXml.ps1
+++ b/VcRedist/Public/Export-VcXml.ps1
@@ -68,6 +68,6 @@ Function Export-VcXml {
         # Write the document out to the file system and return the path to the file.
         Write-Verbose "Writing XML to $Path."
         $xmlDocument.Save($Path)
-        $Path
+        Write-Output $Path
     }
 }

--- a/VcRedist/Public/Get-VcList.ps1
+++ b/VcRedist/Public/Get-VcList.ps1
@@ -91,6 +91,6 @@ Function Get-VcList {
     }
     End {
         # Return array to the pipeline
-        $Output
+        Write-Output $Output
     }
 }

--- a/VcRedist/Public/Get-VcRedist.ps1
+++ b/VcRedist/Public/Get-VcRedist.ps1
@@ -53,19 +53,19 @@ Function Get-VcRedist {
         [Parameter(Mandatory = $True, Position = 0, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $False, `
                 HelpMessage = ".")]
         [ValidateNotNull()]
-        [array]$VcList,
+        [array] $VcList,
 
         [Parameter(Mandatory = $False, Position = 1, HelpMessage = "Specify a target path to download the Redistributables to.")]
         [ValidateScript({ If (Test-Path $_ -PathType 'Container') { $True } Else { Throw "Cannot find path $_" } })]
-        [string]$Path,
+        [string] $Path,
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify the version of the Redistributables to download.")]
         [ValidateSet('2005', '2008', '2010', '2012', '2013', '2015', '2017')]
-        [string[]]$Release = @("2008", "2010", "2012", "2013", "2015", "2017"),
+        [string[]] $Release = @("2008", "2010", "2012", "2013", "2015", "2017"),
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify the processor architecture/s to download.")]
         [ValidateSet('x86', 'x64')]
-        [string[]]$Architecture = @("x86", "x64")
+        [string[]] $Architecture = @("x86", "x64")
     )
     Begin {
         $Output = @()
@@ -125,6 +125,6 @@ Function Get-VcRedist {
     }
     End {
         # Return the $VcList array on the pipeline so that we can act on what was downloaded
-        $Output
+        Write-Output $Output
     }
 }

--- a/VcRedist/Public/Import-VcCmApp.ps1
+++ b/VcRedist/Public/Import-VcCmApp.ps1
@@ -52,34 +52,34 @@ Function Import-VcCmApp {
         [Parameter(Mandatory = $True, Position = 0, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $False, `
                 HelpMessage = "An array containing details of the Visual C++ Redistributables from Get-VcList.")]
         [ValidateNotNull()]
-        [array]$VcList,
+        [array] $VcList,
 
         [Parameter(Mandatory = $True, Position = 1, HelpMessage = "A folder containing the downloaded Visual C++ Redistributables.")]
         [ValidateScript( {If (Test-Path $_ -PathType 'Container') { $True } Else { Throw "Cannot find path $_" } })]
-        [string]$Path,
+        [string] $Path,
 
         [Parameter(Mandatory = $True, HelpMessage = "Specify a distribution UNC path to copy the Redistributables to.")]
-        [string]$CMPath,
+        [string] $CMPath,
 
         [Parameter(Mandatory = $True, HelpMessage = "Specify ConfigMgr Site Code.")]
         [ValidateScript( { If ($_ -match "^[a-zA-Z0-9]{3}$") { $True } Else { Throw "$_ is not a valid ConfigMgr site code." } })]
-        [string]$SMSSiteCode,
+        [string] $SMSSiteCode,
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify Applications folder to import the VC Redistributables into.")]
         [ValidatePattern('^[a-zA-Z0-9]+$')]
-        [string]$AppFolder = "VcRedists",
+        [string] $AppFolder = "VcRedists",
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify the version of the Redistributables to install.")]
         [ValidateSet('2005', '2008', '2010', '2012', '2013', '2015', '2017')]
-        [string[]]$Release = @("2008", "2010", "2012", "2013", "2015", "2017"),
+        [string[]] $Release = @("2008", "2010", "2012", "2013", "2015", "2017"),
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify the processor architecture/s to install.")]
         [ValidateSet('x86', 'x64')]
-        [string[]]$Architecture = @("x86", "x64"),
+        [string[]] $Architecture = @("x86", "x64"),
 
-        [Parameter()]$Publisher = "Microsoft",
-        [Parameter()]$Language = "en-US",
-        [Parameter()]$Keyword = "Visual C++ Redistributable"
+        [Parameter()] $Publisher = "Microsoft",
+        [Parameter()] $Language = "en-US",
+        [Parameter()] $Keyword = "Visual C++ Redistributable"
     )
     Begin {        
         # CMPath will be the network location for copying the Visual C++ Redistributables to
@@ -196,6 +196,6 @@ Function Import-VcCmApp {
         Set-Location -Path $Path
 
         # Output array of applications created in ConfigMgr
-        $Output
+        Write-Output $Output
     }
 }

--- a/VcRedist/Public/Import-VcMdtApp.ps1
+++ b/VcRedist/Public/Import-VcMdtApp.ps1
@@ -56,36 +56,36 @@ Function Import-VcMdtApp {
         [Parameter(Mandatory = $True, Position = 0, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $False, `
                 HelpMessage = "An array containing details of the Visual C++ Redistributables from Get-VcList.")]
         [ValidateNotNull()]
-        [array]$VcList,
+        [array] $VcList,
 
         [Parameter(Mandatory = $True, Position = 1, HelpMessage = "A folder containing the downloaded Visual C++ Redistributables.")]
         [ValidateScript( { If (Test-Path $_ -PathType 'Container') { $True } Else { Throw "Cannot find path $_" } })]
-        [string]$Path,
+        [string] $Path,
 
         [Parameter(Mandatory = $True, HelpMessage = "The path to the MDT deployment share.")]
         [ValidateScript( { If (Test-Path $_ -PathType 'Container') { $True } Else { Throw "Cannot find path $_" } })]
-        [string]$MdtPath,
+        [string] $MdtPath,
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify Applications folder to import the VC Redistributables into.")]
         [ValidatePattern('^[a-zA-Z0-9]+$')]
         [ValidateNotNullOrEmpty()]
-        [string]$AppFolder = "VcRedists",
+        [string] $AppFolder = "VcRedists",
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify the version of the Redistributables to install.")]
         [ValidateSet('2005', '2008', '2010', '2012', '2013', '2015', '2017')]
-        [string[]]$Release = @("2008", "2010", "2012", "2013", "2015", "2017"),
+        [string[]] $Release = @("2008", "2010", "2012", "2013", "2015", "2017"),
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify the processor architecture/s to install.")]
         [ValidateSet('x86', 'x64')]
-        [string[]]$Architecture = @("x86", "x64"),
+        [string[]] $Architecture = @("x86", "x64"),
 
         [Parameter(Mandatory = $False, HelpMessage = "Add the imported Visual C++ Redistributables into an Application Bundle.")]
-        [switch]$Bundle,
+        [switch] $Bundle,
 
-        [Parameter()]$mdtDrive = "DS001",
-        [Parameter()]$Publisher = "Microsoft",
-        [Parameter()]$BundleName = "Visual C++ Redistributables",
-        [Parameter()]$Language = "en-US"
+        [Parameter()] $mdtDrive = "DS001",
+        [Parameter()] $Publisher = "Microsoft",
+        [Parameter()] $BundleName = "Visual C++ Redistributables",
+        [Parameter()] $Language = "en-US"
     )
     Begin {
         # If we can find the MDT PowerShell module, import it. Requires MDT console to be installed
@@ -200,6 +200,6 @@ Function Import-VcMdtApp {
             }
         }
         # Return list of apps to the pipeline
-        $Output | Select-Object PSChildName, Source, CommandLine, Version, Language, SupportedPlatform, UninstallKey, Reboot
+        Write-Output ($Output | Select-Object PSChildName, Source, CommandLine, Version, Language, SupportedPlatform, UninstallKey, Reboot)
     }
 }

--- a/VcRedist/VcRedist.psd1
+++ b/VcRedist/VcRedist.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VcRedist.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.2.37'
+ModuleVersion = '1.3.3.37'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -99,7 +99,7 @@ PrivateData = @{
     PSData = @{
 
         # Tags applied to this module. These help with module discovery in online galleries.
-        Tags = 'Redistributables','VisualC'
+        Tags = 'Redistributables','VisualC', 'VisualStudio'
 
         # A URL to the license for this module.
         LicenseUri = 'https://github.com/aaronparker/Install-VisualCRedistributables/blob/master/LICENSE'
@@ -111,7 +111,7 @@ PrivateData = @{
         IconUri = 'https://raw.githubusercontent.com/aaronparker/Install-VisualCRedistributables/master/images/VisualStudioLogo256.png'
 
         # ReleaseNotes of this module
-        # ReleaseNotes = ''
+        ReleaseNotes = 'https://docs.stealthpuppy.com/vcredist/change-log'
 
         # External dependent modules of this module
         # ExternalModuleDependencies = ''

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,83 +1,27 @@
 # Change log
 
-## v1.1.0.36
+## v1.3.2.35
 
-## Public Functions
+- Code formatting updates
+- Use `Join-Path` to build folder/file paths to better work on PSCore
+- Pester tests updates
+- Version update to better align with feature changes
 
-- Fix inline help examples for `Import-LatestUpdate` to address issue #11 
+## v1.3.1.4
 
-## Tests
+- Fixes to ConfigMgr application import
 
-- Update Pester tests in `PublicFunctions.Tests.ps1` to ensure successful tests for `Get-LatestUpdate` using `Should -Not -BeNullOrEmpty`
+## v1.3.1.2
 
-## v1.1.0.34
+- Add `-Bundle` to `Import-VcMdtApp` to create an Application Bundle with the Redistributables as dependencies. Redistributables will be hidden so that only the Bundle is selectable in the deployment wizard
+- Updating simple Pester tests and getting Appveyor integration working
+- Cleanup inline help
+- Generated external help with platyPS
 
-### General
+## v1.3.1.0
 
-- Update module version
-- Inline help updates
-- Module description updates
+- Added function Import-VcCmApp for importing Visual C++ Redistributables into ConfigMgr.
 
-### Public Functions
+## v1.3.0.0
 
-- Add support for Windows 8.1 / 7 (and Windows Server 2012 R2 / 2008 R2) to `Get-LatestUpdate`
-- Change parameters with -WindowsVersion, -Build, -Architecture in `Get-LatestUpdate` to support Windows OS changes
-
-### Private Functions
-- Add private function New-DynamicParam to support -WindowsVersion, -Build, -Architecture in `Get-LatestUpdate`
-
-### Tests
-
-- Update Pester tests
-
-## v1.0.1.27
-
-### General
-
-- Inline help updates, code style formatting
-- Update module description
-- Update module release notes link
-
-### Private functions
-
-- Add `Test-PSCore` for testing when environment is PowerShell Core
-- Add suppression of PSUseDeclaredVarsMoreThanAssignments for PSScriptAnalyzer false positive in `Select-LatestUpdate`; Pester tests now test `Select-LatestUpdate`
-
-### Public functions
-
-- Update `Get-LatestUpdate` and `Save-LatestUpdate` with support for PowerShell Core
-- Better error handling in `Import-LatestUpdate`
-
-### Tests
-
-- Add Pester tests for `Test-PSCore`
-
-## v1.0.1.20
-
-
-### General
-
-- Fix ProjectUri
-
-### Private functions
-
-- Rename `Get-ValidPath`
-- Simplify `Import-MdtModule` output
-- Add `New-MdtDrive`
-- Improve `New-MdtPackagesFolder` robustness, update output
-- Add `Remove-MdtDrive`
-- Update `Select-LatestUpdate` notes
-- Update `Select-UniqueUrl` notes
-
-### Public functions
-- Update `Get-LatestUpdate` inline help
-- Update `Import-LatestUpdate` inline help, parameters, new MDT drive, more robust action when creating the MDT package folder
-- Fix pipeline support for `Save-LatestUpdate`
-
-### Tests
-- Detailed Pester tests for Private and Public functions
-
-## v1.0.1.11
-
-- First v1 public release
-- Published to the [PowerShell Gallery](https://www.powershellgallery.com/packages/LatestUpdate/)
+- Refactored into a PowerShell module to simplify coding and publishing to the PowerShell Gallery.


### PR DESCRIPTION
# Update 2017 VcRedists to 14.13 release

- Update manifests to point to 14.13 releases for VS 2017
- Update module ReleaseNote property to point to https://docs.stealthpuppy.com/vcredist/change-log
- Fix change-log details
- Use explicit Write-Output for functions