### PR TITLE
Corrected File Path in Readme

### DIFF
--- a/docs/install-windows.MD
+++ b/docs/install-windows.MD
@@ -5,7 +5,7 @@ To install the Visual C++ Redistributables on the local machine, use `Install-Vc
 The following command will install the Visual C++ Redistributables already downloaded locally with `Get-VcRedist` to C:\Temp\VcRedist.
 
 ```powershell
-Get-VcList | Install-VcRedist -Path C:\Temp\VcRedists
+Get-VcList | Install-VcRedist -Path C:\Temp\VcRedist
 ```
 
 Visual C++ Redistributables can be filtered for release and processor architecture.


### PR DESCRIPTION
Corrected File Path To match the file Path listed in the sentence above and in the other sections such as
https://docs.stealthpuppy.com/vcredist/usage/downloading-the-redistributables

