### PR TITLE
Development

### DIFF
--- a/VcRedist/Public/Import-VcMdtApp.ps1
+++ b/VcRedist/Public/Import-VcMdtApp.ps1
@@ -148,8 +148,13 @@ Function Import-VcMdtApp {
                 $source = "$($(Get-Item -Path $Path).FullName)\$($Vc.Release)\$($Vc.Architecture)\$($Vc.ShortName)"
                 $filename = Split-Path -Path $Vc.Download -Leaf
                 $dir = "$Publisher VcRedist\$($Vc.Release) $($Vc.ShortName) $($Vc.Architecture)"
-                $supportedPlatform = If ($Vc.Architecture -eq "x86") { "All x86 Windows 7 and Newer" } `
-                    Else { @("All x64 Windows 7 and Newer", "All x86 Windows 7 and Newer") }
+
+                # Supported platforms might be better coming from the XML manifest
+                # This is basically hard coding the target platform
+                $supportedPlatform = If ($Vc.Architecture -eq "x86") {
+                    @("All x86 Windows 7 and Newer", "All x64 Windows 7 and Newer") 
+                } `
+                    Else { "All x64 Windows 7 and Newer" }
 
                 Import-MDTApplication -Path $target `
                     -Name "$Publisher $($Vc.Name) $($Vc.Architecture)" `

--- a/VcRedist/Public/Import-VcMdtApp.ps1
+++ b/VcRedist/Public/Import-VcMdtApp.ps1
@@ -131,6 +131,7 @@ Function Import-VcMdtApp {
         Else {
             $target = "$($mdtDrive):\Applications"
         }
+        Write-Verbose "Importing applications into $target"
     }
     Process {
         # Filter release and architecture if specified

--- a/VcRedist/Public/Import-VcMdtApp.ps1
+++ b/VcRedist/Public/Import-VcMdtApp.ps1
@@ -117,12 +117,15 @@ Function Import-VcMdtApp {
         # Create a sub-folder below Applications to import the Redistributables into, if $AppFolder not null
         # Create $target as the target Application folder to import into
         If ( $AppFolder.Length -ne 0 ) {
-            If (!(Test-Path -Path "$($mdtDrive):\Applications\$($AppFolder)")) {
+            If ((Test-Path -Path "$($mdtDrive):\Applications\$($AppFolder)")) {
+                $target = "$($mdtDrive):\Applications\$($AppFolder)"
+            }
+            Else {
                 If ($PSCmdlet.ShouldProcess("$($mdtDrive):\Applications\$($AppFolder)", "Creating folder")) {
                     New-Item -Path "$($mdtDrive):\Applications" -Enable "True" -Name $AppFolder `
                         -Comments "$($Publisher) $($BundleName)" -ItemType "Folder" -ErrorAction SilentlyContinue
+                    $target = "$($mdtDrive):\Applications\$($AppFolder)"
                 }
-                $target = "$($mdtDrive):\Applications\$($AppFolder)"
             }
         }
         Else {

--- a/VcRedist/VcRedist.psd1
+++ b/VcRedist/VcRedist.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VcRedist.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.3.39'
+ModuleVersion = '1.3.4.39'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/docs/ISSUES.MD
+++ b/docs/ISSUES.MD
@@ -2,10 +2,4 @@
 
 ## Import-VcMdtApp
 
-If the path specificed by -AppFolder exists, import fails with:
-
-```
-Import-MDTApplication : Cannot bind parameter 'Path' to the target. Exception setting "Path": "Cannot process argument because the value of argument "paths" is null. Change the value of argument "paths" to a non-null value."
-```
-
-Delete the sub-folder of Applications in the MDT share and re-try the import.
+* The bundle doesn't currently add the MDT redistributables in order from oldest to newest. Install order shouldn't matter however.

--- a/docs/ISSUES.MD
+++ b/docs/ISSUES.MD
@@ -1,0 +1,11 @@
+# Known Issues
+
+## Import-VcMdtApp
+
+If the path specificed by -AppFolder exists, import fails with:
+
+```
+Import-MDTApplication : Cannot bind parameter 'Path' to the target. Exception setting "Path": "Cannot process argument because the value of argument "paths" is null. Change the value of argument "paths" to a non-null value."
+```
+
+Delete the sub-folder of Applications in the MDT share and re-try the import.

--- a/docs/SUMMARY.MD
+++ b/docs/SUMMARY.MD
@@ -19,3 +19,4 @@
     * [Import-VcMdtApp](Import-VcMdtApp.md)
     * [Import-VcCmApp](Import-VcCmApp.md)
 * [Change log](CHANGELOG.md)
+* [Known issues](ISSUES.MD)

--- a/tests/Install.ps1
+++ b/tests/Install.ps1
@@ -8,7 +8,7 @@ Write-Host "PowerShell Version:" $PSVersionTable.PSVersion.tostring()
 
 Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 Install-Module -Name Pester -Force
-Install-Module -Name PSScriptAnalyzer -Force
+Install-Module -Name PSScriptAnalyzer -SkipPublisherCheck -Force
 Install-Module -Name posh-git -Force
 
 # Import the module


### PR DESCRIPTION
# Description

* Fix import of Redistributables with correct x86, x64 platform selection in MDT application in `Import-VcMdtApp`
* Fix import of Redistributables into a folder specified by `-AppFolder` where the folder already exists in `Import-VcMdtApp`
