### PR TITLE
Development

### DIFF
--- a/VcRedist/Manifests/VisualCRedistributablesAll.xml
+++ b/VcRedist/Manifests/VisualCRedistributablesAll.xml
@@ -227,22 +227,24 @@
             <Download>https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe</Download>
         </Redistributable>
     </Platform>
+    <Platform Architecture="x64" Release="2013" Install="/install /passive /norestart">
+        <Redistributable>
+            <Name>Microsoft Visual C++ 2013 Update 5 Redistributable Package</Name>
+            <ShortName>Update5</ShortName>
+            <URL>https://support.microsoft.com/en-us/help/4032938/update-for-visual-c-2013-redistributable-package</URL>
+            <ProductCode>{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}</ProductCode>
+            <Version>12.0.40664.0</Version>
+            <Download>https://download.visualstudio.microsoft.com/download/pr/10912041/cee5d6bca2ddbcd039da727bf4acb48a/vcredist_x64.exe</Download>
+        </Redistributable>
+    </Platform>
     <Platform Architecture="x86" Release="2013" Install="/install /passive /norestart">
         <Redistributable>
-            <Name>Visual C++ Redistributable Packages for Visual Studio 2013</Name>
-            <ShortName>RTM</ShortName>
-            <URL>https://www.microsoft.com/en-us/download/details.aspx?id=40784</URL>
-            <ProductCode>{f65db027-aff3-4070-886a-0d87064aabb1}</ProductCode>
-            <Version>12.0.30501.0</Version>
-            <Download>https://download.microsoft.com/download/2/E/6/2E61CFA4-993B-4DD4-91DA-3737CD5CD6E3/vcredist_x86.exe</Download>
-        </Redistributable>
-        <Redistributable>
-            <Name>Update for Visual C++ 2013 and Visual C++ Redistributable Package</Name>
-            <ShortName>Update</ShortName>
-            <URL>https://support.microsoft.com/en-us/help/3179560/update-for-visual-c-2013-and-visual-c-redistributable-package</URL>
-            <ProductCode>{61087a79-ac85-455c-934d-1fa22cc64f36}</ProductCode>
-            <Version>12.0.40660.0</Version>
-            <Download>https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe</Download>
+            <Name>Microsoft Visual C++ 2013 Update 5 Redistributable Package</Name>
+            <ShortName>Update5</ShortName>
+            <URL>https://support.microsoft.com/en-us/help/4032938/update-for-visual-c-2013-redistributable-package</URL>
+            <ProductCode>{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}</ProductCode>
+            <Version>12.0.40664.0</Version>
+            <Download>https://download.visualstudio.microsoft.com/download/pr/10912113/5da66ddebb0ad32ebd4b922fd82e8e25/vcredist_x86.exe</Download>
         </Redistributable>
     </Platform>
     <Platform Architecture="x64" Release="2015" Install="/install /passive /norestart">
@@ -272,7 +274,7 @@
             <URL>https://www.visualstudio.com/downloads/</URL>
             <ProductCode>{80586c77-db42-44bb-bfc8-7aebbb220c00}}</ProductCode>
             <Version>14.14.26429.4</Version>
-            <Download>https://aka.ms/vs/15/release/vc_redist.x86.exe</Download>
+            <Download>https://aka.ms/vs/15/release/vc_redist.x64.exe</Download>
         </Redistributable>
     </Platform>
     <Platform Architecture="x86" Release="2017" Install="/install /passive /norestart">
@@ -282,7 +284,7 @@
             <URL>https://www.visualstudio.com/downloads/</URL>
             <ProductCode>{2019b6a0-8533-4a04-ac0e-b2c10bdb9841}</ProductCode>
             <Version>14.14.26429.4</Version>
-            <Download>https://aka.ms/vs/15/release/vc_redist.x64.exe</Download>
+            <Download>https://aka.ms/vs/15/release/vc_redist.x86.exe</Download>
         </Redistributable>
     </Platform>
 </Redistributables>

--- a/VcRedist/Manifests/VisualCRedistributablesSupported.xml
+++ b/VcRedist/Manifests/VisualCRedistributablesSupported.xml
@@ -63,22 +63,22 @@
     </Platform>
     <Platform Architecture="x64" Release="2013" Install="/install /passive /norestart">
         <Redistributable>
-            <Name>Update for Visual C++ 2013 and Visual C++ Redistributable Package</Name>
-            <ShortName>Update</ShortName>
-            <URL>https://support.microsoft.com/en-us/help/3179560/update-for-visual-c-2013-and-visual-c-redistributable-package</URL>
-            <ProductCode>{ef6b00ec-13e1-4c25-9064-b2f383cb8412}</ProductCode>
-            <Version>12.0.40660.0</Version>
-            <Download>https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x64.exe</Download>
+            <Name>Microsoft Visual C++ 2013 Update 5 Redistributable Package</Name>
+            <ShortName>Update5</ShortName>
+            <URL>https://support.microsoft.com/en-us/help/4032938/update-for-visual-c-2013-redistributable-package</URL>
+            <ProductCode>{042d26ef-3dbe-4c25-95d3-4c1b11b235a7}</ProductCode>
+            <Version>12.0.40664.0</Version>
+            <Download>https://download.visualstudio.microsoft.com/download/pr/10912041/cee5d6bca2ddbcd039da727bf4acb48a/vcredist_x64.exe</Download>
         </Redistributable>
     </Platform>
     <Platform Architecture="x86" Release="2013" Install="/install /passive /norestart">
         <Redistributable>
-            <Name>Update for Visual C++ 2013 and Visual C++ Redistributable Package</Name>
-            <ShortName>Update</ShortName>
-            <URL>https://support.microsoft.com/en-us/help/3179560/update-for-visual-c-2013-and-visual-c-redistributable-package</URL>
-            <ProductCode>{61087a79-ac85-455c-934d-1fa22cc64f36}</ProductCode>
-            <Version>12.0.40660.0</Version>
-            <Download>https://download.microsoft.com/download/0/5/6/056dcda9-d667-4e27-8001-8a0c6971d6b1/vcredist_x86.exe</Download>
+            <Name>Microsoft Visual C++ 2013 Update 5 Redistributable Package</Name>
+            <ShortName>Update5</ShortName>
+            <URL>https://support.microsoft.com/en-us/help/4032938/update-for-visual-c-2013-redistributable-package</URL>
+            <ProductCode>{9dff3540-fc85-4ed5-ac84-9e3c7fd8bece}</ProductCode>
+            <Version>12.0.40664.0</Version>
+            <Download>https://download.visualstudio.microsoft.com/download/pr/10912113/5da66ddebb0ad32ebd4b922fd82e8e25/vcredist_x86.exe</Download>
         </Redistributable>
     </Platform>
     <Platform Architecture="x64" Release="2015" Install="/install /passive /norestart">

--- a/VcRedist/Private/Get-FileMetadata.ps1
+++ b/VcRedist/Private/Get-FileMetadata.ps1
@@ -1,0 +1,93 @@
+Function Get-FileMetadata {
+    <#
+        .SYNOPSIS
+            Get file metadata from files in a target folder.
+        
+        .DESCRIPTION
+            Retreives file metadata from files in a target path, or file paths, to display information on the target files.
+            Useful for understanding application files and identifying metadata stored in them. Enables the administrator to view metadata for application control scenarios.
+
+        .NOTES
+            Author: Aaron Parker
+            Twitter: @stealthpuppy
+        
+        .LINK
+            https://github.com/aaronparker/Install-VisualCRedistributables
+
+        .OUTPUTS
+            [System.Array]
+
+        .PARAMETER Path
+            A target path in which to scan files for metadata.
+
+        .PARAMETER Include
+            Gets only the specified items.
+
+        .EXAMPLE
+            Get-FileMetadata -Path "C:\Users\aaron\AppData\Local\GitHubDesktop"
+
+            Description:
+            Scans the folder specified in the Path variable and returns the metadata for each file.
+    #>
+    [CmdletBinding(SupportsShouldProcess = $False)]
+    [OutputType([Array])]
+    Param (
+        [Parameter(Mandatory = $True, Position = 0, ValueFromPipeline = $True, ValueFromPipelineByPropertyName = $True, `
+                HelpMessage = 'Specify a target path, paths or a list of files to scan for metadata.')]
+        [Alias('FullName', 'PSPath')]
+        [string[]]$Path,
+
+        [Parameter(Mandatory = $False, Position = 1, ValueFromPipeline = $False, `
+                HelpMessage = 'Gets only the specified items.')]
+        [Alias('Filter')]
+        [string[]]$Include = @('*.exe', '*.dll', '*.ocx', '*.msi', '*.ps1', '*.vbs', '*.js', '*.cmd', '*.bat')
+    )
+    Begin {
+        # Measure time taken to gather data
+        $StopWatch = [system.diagnostics.stopwatch]::StartNew()
+
+        # RegEx to grab CN from certificates
+        $FindCN = "(?:.*CN=)(.*?)(?:,\ O.*)"
+
+        Write-Verbose "Beginning metadata trawling."
+        $Files = @()
+    }
+    Process {
+        # For each path in $Path, check that the path exists
+        ForEach ($Loc in $Path) {
+            If (Test-Path -Path $Loc -IsValid) {
+                # Get the item to determine whether it's a file or folder
+                If ((Get-Item -Path $Loc).PSIsContainer) {
+                    # Target is a folder, so trawl the folder for .exe and .dll files in the target and sub-folders
+                    Write-Verbose "Getting metadata for files in folder: $Loc"
+                    $items = Get-ChildItem -Path $Loc -Recurse -Include $Include
+                }
+                Else {
+                    # Target is a file, so just get metadata for the file
+                    Write-Verbose "Getting metadata for file: $Loc"
+                    $items = Get-Item -Path $Loc
+                }
+
+                # Create an array from what was returned for specific data and sort on file path
+                $Files += $items | Select-Object @{Name = "Path"; Expression = {$_.FullName}}, `
+                @{Name = "Owner"; Expression = {(Get-Acl -Path $_.FullName).Owner}}, `
+                @{Name = "Vendor"; Expression = {$(((Get-AcDigitalSignature -Path $_ -ErrorAction SilentlyContinue).Subject -replace $FindCN, '$1') -replace '"', "")}}, `
+                @{Name = "Company"; Expression = {$_.VersionInfo.CompanyName}}, `
+                @{Name = "Description"; Expression = {$_.VersionInfo.FileDescription}}, `
+                @{Name = "Product"; Expression = {$_.VersionInfo.ProductName}}, `
+                @{Name = "ProductVersion"; Expression = {$_.VersionInfo.ProductVersion}}, `
+                @{Name = "FileVersion"; Expression = {$_.VersionInfo.FileVersion}}
+            }
+            Else {
+                Write-Error "Path does not exist: $Loc"
+            }
+        }
+    }
+    End {
+
+        # Return the array of file paths and metadata
+        $StopWatch.Stop()
+        Write-Verbose "Metadata trawling complete. Script took $($StopWatch.Elapsed.TotalMilliseconds) ms to complete."
+        Return $Files | Sort-Object -Property Path
+    }
+}

--- a/VcRedist/Private/Get-InstalledSoftware.ps1
+++ b/VcRedist/Private/Get-InstalledSoftware.ps1
@@ -44,7 +44,8 @@ Function Get-InstalledSoftware {
             $selectProperties = @(
                 @{n = 'Name'; e = {$_.GetValue('DisplayName')}},
                 @{n = 'Version'; e = {$_.GetValue('DisplayVersion')}},
-                @{n = 'ProductCode'; e = {$_.PSChildName}}
+                @{n = 'ProductCode'; e = {$_.PSChildName}},
+                @{n = 'UninstallString'; e = {$_.GetValue('UninstallString')}}
             )
             Get-ChildItem @gciParams | Where-Object $WhereBlock | Select-Object -Property $selectProperties
         }

--- a/VcRedist/Public/Get-InstalledVcRedist.ps1
+++ b/VcRedist/Public/Get-InstalledVcRedist.ps1
@@ -31,8 +31,8 @@ Function Get-InstalledVcRedist {
             Description:
             Returns the installed Microsoft Visual C++ Redistributables from the current system including the Additional and Minimum Runtimes.
     #>
-    [CmdletBinding(SupportsShouldProcess = $False)]
     [OutputType([System.Management.Automation.PSObject])]
+    [CmdletBinding(SupportsShouldProcess = $False)]
     Param (
         [Parameter(Mandatory = $False)]
         [switch] $ExportAll
@@ -46,7 +46,11 @@ Function Get-InstalledVcRedist {
         $VcRedists = $VcRedists | ForEach-Object { If (-not (Select-String -InputObject $_ -Pattern "Additional|Minimum")) {$_} } | `
             Sort-Object Name
     }
-    
+
+    # Add Architecture property to each entry
+    $VcRedists | ForEach-Object { If ( $_.Name -contains "x64" ) `
+        { $_ | Add-Member -NotePropertyName "Architecture" -NotePropertyValue "x64" } }
+        
     # Write the installed VcRedists to the pipeline
     Write-Output $VcRedists
 }

--- a/VcRedist/Public/Get-VcList.ps1
+++ b/VcRedist/Public/Get-VcList.ps1
@@ -37,8 +37,8 @@ Function Get-VcList {
         Description:
         Return an array of the Visual C++ Redistributables listed in VisualCRedistributablesSupported.xml.
     #>
+    [OutputType([System.Management.Automation.PSObject])]
     [CmdletBinding(SupportsShouldProcess = $False)]
-    [OutputType([Array])]
     Param (
         [Parameter(Mandatory = $False, Position = 0, HelpMessage = "Path to the XML document describing the Redistributables.")]
         [ValidateNotNull()]

--- a/VcRedist/Public/Get-VcRedist.ps1
+++ b/VcRedist/Public/Get-VcRedist.ps1
@@ -100,24 +100,26 @@ Function Get-VcRedist {
                     New-Item -Path $folder -Type Directory -Force -ErrorAction SilentlyContinue | Out-Null
                 }
             }
-
-            # If the target Redistributable is already downloaded, compare the version
+            
             $target = Join-Path $folder $(Split-Path -Path $Vc.Download -Leaf)
-            Write-Verbose "Target is $($target)"
-            $download = $True
+            Write-Verbose "Testing target: $($target)"
             If ( Test-Path -Path $target -PathType Leaf ) {
-                Write-Verbose "$($target) exists. Comparing versions."
                 $ProductVersion = $(Get-FileMetadata -Path $target).ProductVersion
+                # If the target Redistributable is already downloaded, compare the version
                 If ( ($Vc.Version -gt $ProductVersion) -or ($Null -eq $ProductVersion) ) {
                     # Download the newer version
-                    Write-Verbose "$($Vc.Version) > $ProductVersion. Downloading."
+                    Write-Verbose "$($Vc.Version) > $ProductVersion."
                     $download = $True
                 }
                 Else {
-                    # No need to download
+                    Write-Verbose "Manifest version: $($Vc.Version) matches file version: $ProductVersion."
                     $download = $False
                 }
             }
+            Else {
+                $download = $True
+            }
+
             If ($download) {
                 # If running on Windows PowerShell use Start-BitsTransfer, otherwise use Invoke-WebRequest
                 If ( Get-Command Start-BitsTransfer -ErrorAction SilentlyContinue ) {
@@ -132,6 +134,9 @@ Function Get-VcRedist {
                         Invoke-WebRequest -Uri $Vc.Download -OutFile $target
                     }
                 }
+            }
+            Else {
+                Write-Verbose "$($target) exists."
             }
         }
     }

--- a/VcRedist/Public/Get-VcRedist.ps1
+++ b/VcRedist/Public/Get-VcRedist.ps1
@@ -57,7 +57,7 @@ Function Get-VcRedist {
         [array] $VcList,
 
         [Parameter(Mandatory = $False, Position = 1, HelpMessage = "Specify a target path to download the Redistributables to.")]
-        [ValidateScript({ If (Test-Path $_ -PathType 'Container') { $True } Else { Throw "Cannot find path $_" } })]
+        [ValidateScript( { If (Test-Path $_ -PathType 'Container') { $True } Else { Throw "Cannot find path $_" } })]
         [string] $Path,
 
         [Parameter(Mandatory = $False, HelpMessage = "Specify the version of the Redistributables to download.")]
@@ -101,14 +101,25 @@ Function Get-VcRedist {
                 }
             }
 
-            # If the target Redistributable is already downloaded, skip it.
-            # If running on Windows PowerShell use Start-BitsTransfer, otherwise use Invoke-WebRequest
+            # If the target Redistributable is already downloaded, compare the version
             $target = Join-Path $folder $(Split-Path -Path $Vc.Download -Leaf)
             Write-Verbose "Target is $($target)"
+            $download = $True
             If ( Test-Path -Path $target -PathType Leaf ) {
-                Write-Verbose "$($target) exists. Skipping."
+                Write-Verbose "$($target) exists. Comparing versions."
+                $ProductVersion = $(Get-FileMetadata -Path $target).ProductVersion
+                If ( ($Vc.Version -gt $ProductVersion) -or ($Null -eq $ProductVersion) ) {
+                    # Download the newer version
+                    Write-Verbose "$($Vc.Version) > $ProductVersion. Downloading."
+                    $download = $True
+                }
+                Else {
+                    # No need to download
+                    $download = $False
+                }
             }
-            Else {
+            If ($download) {
+                # If running on Windows PowerShell use Start-BitsTransfer, otherwise use Invoke-WebRequest
                 If ( Get-Command Start-BitsTransfer -ErrorAction SilentlyContinue ) {
                     If ( $pscmdlet.ShouldProcess($Vc.Download, "BitsDownload") ) {
                         Start-BitsTransfer -Source $Vc.Download -Destination $target `

--- a/VcRedist/Public/Install-VcRedist.ps1
+++ b/VcRedist/Public/Install-VcRedist.ps1
@@ -65,7 +65,8 @@ Function Install-VcRedist {
         [bool]$Elevated = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")
         If ( !($Elevated) ) { Throw "Installing the Visual C++ Redistributables requires elevation."}
         
-        $UninstallPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall", "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
+        # $UninstallPath = "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall", "HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
+        $Installed = Get-InstalledVcRedist
     }
     Process {
         # Filter release and architecture if specified
@@ -80,7 +81,10 @@ Function Install-VcRedist {
 
         # Loop through each Redistributable and install
         ForEach ( $Vc in $VcList ) {
-            If (Get-ChildItem -Path $UninstallPath | Where-Object { $_.Name -like "*$($Vc.ProductCode)" }) {
+            # If (Get-ChildItem -Path $UninstallPath | Where-Object { $_.Name -like "*$($Vc.ProductCode)" }) {
+            #    Write-Verbose "Skip:    [$($Vc.Release)][$($Vc.Architecture)][$($Vc.Name)]"
+            #}
+            If ($Installed | Where-Object { $Vc.ProductCode -contains $_.ProductCode }) {
                 Write-Verbose "Skip:    [$($Vc.Release)][$($Vc.Architecture)][$($Vc.Name)]"
             }
             Else {

--- a/VcRedist/VcRedist.psd1
+++ b/VcRedist/VcRedist.psd1
@@ -12,7 +12,7 @@
 RootModule = 'VcRedist.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.3.6.56'
+ModuleVersion = '1.3.7.56'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/docs/SUMMARY.MD
+++ b/docs/SUMMARY.MD
@@ -23,4 +23,3 @@
   * [Get-InstalledVcRedist](function-syntax/get-installedvcredist.md)
 * [Change log](change-log.md)
 * [Known issues](known-issues.md)
-

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -23,4 +23,3 @@
   * [Get-InstalledVcRedist](function-syntax/get-installedvcredist.md)
 * [Change log](change-log.md)
 * [Known issues](known-issues.md)
-

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -3,7 +3,8 @@
 ## v1.3.7.xx
 
 * Update manifests with `2013`, version `12.0.40664`
-* Add `UninstallString` to function `Get-InstalledVcRedist` output
+* Added `UninstallString` to function `Get-InstalledVcRedist` output
+* `Get-VcList` will attempt to match the VcRedist version in the manifest to the `Product Version` property on an existing downloaded file. If the manifest has a higher version, the file will be re-downloaded
 
 ## v1.3.6.56
 
@@ -52,4 +53,3 @@
 ## v1.3.0.0
 
 * Refactored into a PowerShell module to simplify coding and publishing to the PowerShell Gallery.
-

--- a/docs/change-log.md
+++ b/docs/change-log.md
@@ -1,5 +1,10 @@
 # Change log
 
+## v1.3.7.xx
+
+* Update manifests with `2013`, version `12.0.40664`
+* Add `UninstallString` to function `Get-InstalledVcRedist` output
+
 ## v1.3.6.56
 
 * Add `Get-InstalledVcRedist`, using private function `Get-InstalledSoftware`. Closing issue \#18 with feature request for this function. `Get-InstallSoftware` function by [Adam Bertram](https://4sysops.com/archives/find-the-product-guid-of-installed-software-with-powershell/)

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -4,3 +4,4 @@
 
 * The bundle doesn't currently add the MDT redistributables in order from oldest to newest. Install order shouldn't matter however
 * 'English - United States' is the only supported language. The module will only download the en-US versions of the Redistributables
+* `Get-VcList` will attempt to match the VcRedist version in the manifest to the `Product Version` property on the downloaded file. Because Product Version on the 2005 and 2008 VcRedist installers doesn't match the file will be redownloaded even though the installer is the correct version

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -2,5 +2,5 @@
 
 ## Import-VcMdtApp
 
-* The bundle doesn't currently add the MDT redistributables in order from oldest to newest. Install order shouldn't matter however.
-
+* The bundle doesn't currently add the MDT redistributables in order from oldest to newest. Install order shouldn't matter however
+* 'English - United States' is the only supported language. The module will only download the en-US versions of the Redistributables

--- a/scripts/Uninstall-VcRedist.ps1
+++ b/scripts/Uninstall-VcRedist.ps1
@@ -1,0 +1,5 @@
+$InstalledVcRedists = Get-InstalledVcRedist
+ForEach ($VcRedist in $InstalledVcRedists) {
+    Write-Host $VcRedist.Name
+    Start-Process -FilePath "$env:SystemRoot\System32\cmd.exe" -ArgumentList "/c $($VcRedist.UninstallString) /passive" -Wait
+}


### PR DESCRIPTION
# Description

* Update manifests with `2013`, version `12.0.40664`
* Added `UninstallString` to function `Get-InstalledVcRedist` output
* `Get-VcList` will attempt to match the VcRedist version in the manifest to the `Product Version` property on an existing downloaded file. If the manifest has a higher version, the file will be re-downloaded
* Added private function `Get-FileMetadata` to support retrieving `Product Version` from downloaded file
* Update logic in `Install-VcRedist` when querying for installed VcRedists

## Motivation and Context

Update 2013 VcRedist versions.
Improve VcRedist download action

## How Has This Been Tested?

* Tested on Windows 10

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
